### PR TITLE
Fix for stringr 1.6.0

### DIFF
--- a/R/seq_misc_operations.R
+++ b/R/seq_misc_operations.R
@@ -86,6 +86,7 @@ seq_spellout <- function(x, short = FALSE, collapse = " - "){
   if(is_aa(x) & short) dic <- dic_aa()$short_description
 
   out <- stringr::str_split(x, "")
+  out <- unname(out)
   out <- lapply(out, function(x) dic[x])
 
   if(is.character(collapse)){
@@ -94,7 +95,3 @@ seq_spellout <- function(x, short = FALSE, collapse = " - "){
     lapply(out, `names<-`, NULL)
   }
 }
-
-
-
-


### PR DESCRIPTION
`str_split()` now preserves names which was causing your tests to fail.